### PR TITLE
fix: upgrade ruby to 3.4 and unpin bundler

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1' # Not needed with a .ruby-version file
+          ruby-version: '3.4' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
       - name: Setup Pages

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,5 +179,3 @@ CHECKSUMS
   unicode-display_width (2.6.0) sha256=12279874bba6d5e4d2728cef814b19197dbb10d7a7837a869bab65da943b7f5a
   webrick (1.9.2) sha256=beb4a15fc474defed24a3bda4ffd88a490d517c9e4e6118c3edce59e45864131
 
-BUNDLED WITH
-  4.0.3


### PR DESCRIPTION
Upgrades the CI Ruby version to 3.4 to satisfy gem dependencies (public_suffix) and unpins the bundler version in Gemfile.lock to prevent installation errors.