### PR TITLE
feat: add google analytics tracking

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -25,6 +25,13 @@ tasks:
     cmds:
       - bundle exec jekyll serve --livereload --host 0.0.0.0
 
+  run:prod:
+    desc: Run content website in production mode (enables analytics)
+    deps:
+      - deps
+    cmds:
+      - JEKYLL_ENV=production bundle exec jekyll serve --livereload --host 0.0.0.0
+
   ##
   ## Dependencies
   ##

--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,9 @@ linkedin_url: "https://www.linkedin.com/company/agntcyproject"
 youtube_url: "https://www.youtube.com/@agntcy-lf"
 slack_url: "https://join.slack.com/t/agntcy/shared_invite/zt-3hb4p7bo0-5H2otGjxGt9OQ1g5jzK_GQ"
 
+# Google Tag (gtag.js)
+google_analytics: "G-3D9938KZCN"
+
 # Header navigation - explicitly list pages to show
 header_pages:
   - archive.md

--- a/_includes/google-tag.html
+++ b/_includes/google-tag.html
@@ -1,0 +1,9 @@
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', '{{ site.google_analytics }}');
+</script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,12 +7,12 @@
   <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">
   {%- feed_meta -%}
   {%- if jekyll.environment == 'production' and site.google_analytics -%}
-    {%- include google-analytics.html -%}
+    {%- include google-tag.html -%}
   {%- endif -%}
   <script>
     // Set theme immediately to prevent flash of wrong theme
     (function() {
-      const theme = localStorage.getItem('theme-preference') || 
+      const theme = localStorage.getItem('theme-preference') ||
         (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
       document.documentElement.setAttribute('data-theme', theme);
     })();


### PR DESCRIPTION
This PR adds Google Analytics 4 (GA4) tracking to the blog site.

## Changes
- Added `google_analytics` ID to `_config.yml`.
- Created `_includes/google-tag.html` with the standard `gtag.js` snippet.
- Updated `_includes/head.html` to include the tag **only in production environments**.
- Added a `run:prod` task to `Taskfile.yml` for local testing of analytics.

## Testing
- Verified locally using `task run:prod`.
- Confirmed 'Realtime' data flow in Google Analytics dashboard.