### PR TITLE
feat: add GDPR cookie consent banner

### DIFF
--- a/_includes/cookie-consent.html
+++ b/_includes/cookie-consent.html
@@ -1,0 +1,61 @@
+<style>
+    #cookie-notice {padding: 0.5rem 1rem; display: none; text-align: center; position: fixed; bottom: 0; width: calc(100% - 2rem); background: #222; color: rgba(255,255,255,0.8); z-index: 1000;}
+    #cookie-notice a {display: inline-block; cursor: pointer; margin-left: 0.5rem;}
+    @media (max-width: 767px) {
+        #cookie-notice span {display: block; padding-top: 3px; margin-bottom: 1rem;}
+        #cookie-notice a {position: relative; bottom: 4px;}
+    }
+</style>
+<div id="cookie-notice"><span>We would like to use third party cookies and scripts to improve the functionality of this website.</span><a id="cookie-notice-accept" class="btn btn-primary btn-sm">Approve</a></div>
+<script>
+    function createCookie(name,value,days) {
+        var expires = "";
+        if (days) {
+            var date = new Date();
+            date.setTime(date.getTime() + (days*24*60*60*1000));
+            expires = "; expires=" + date.toUTCString();
+        }
+        document.cookie = name + "=" + value + expires + "; path=/";
+    }
+    function readCookie(name) {
+        var nameEQ = name + "=";
+        var ca = document.cookie.split(';');
+        for(var i=0;i < ca.length;i++) {
+            var c = ca[i];
+            while (c.charAt(0)==' ') c = c.substring(1,c.length);
+            if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length,c.length);
+        }
+        return null;
+    }
+    function eraseCookie(name) {
+        createCookie(name,"",-1);
+    }
+
+    function loadGoogleAnalytics() {
+        {% if site.google_analytics and jekyll.environment == 'production' %}
+        // Load Google Analytics V4
+        var script = document.createElement('script');
+        script.async = true;
+        script.src = "https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}";
+        document.head.appendChild(script);
+
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', '{{ site.google_analytics }}');
+        {% endif %}
+    }
+
+    if(readCookie('cookie-notice-dismissed')=='true') {
+        loadGoogleAnalytics();
+    } else {
+        document.getElementById('cookie-notice').style.display = 'block';
+    }
+
+    document.getElementById('cookie-notice-accept').addEventListener("click",function() {
+        createCookie('cookie-notice-dismissed','true',31);
+        document.getElementById('cookie-notice').style.display = 'none';
+        location.reload();
+    });
+
+</script>

--- a/_includes/google-tag.html
+++ b/_includes/google-tag.html
@@ -1,9 +1,0 @@
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', '{{ site.google_analytics }}');
-</script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,9 +6,6 @@
   <link rel="icon" type="image/x-icon" href="{{ "/assets/images/favicon.ico" | relative_url }}">
   <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">
   {%- feed_meta -%}
-  {%- if jekyll.environment == 'production' and site.google_analytics -%}
-    {%- include google-tag.html -%}
-  {%- endif -%}
   <script>
     // Set theme immediately to prevent flash of wrong theme
     (function() {

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -23,7 +23,7 @@
 
       async function renderMermaid() {
         const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        
+
         // Agntcy color scheme for mermaid
         const agntcyTheme = {
           startOnLoad: false,
@@ -94,7 +94,7 @@
             sequenceNumberColor: '#f3f6fd'
           }
         };
-        
+
         mermaid.initialize(agntcyTheme);
         await mermaid.run();
       }
@@ -151,7 +151,7 @@
           observer.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
       });
     </script>
-
+    {% include cookie-consent.html %}
   </body>
 
 </html>


### PR DESCRIPTION
This PR implements a GDPR-compliant cookie consent mechanism.

## Changes
- Created `_includes/cookie-consent.html` which manages the banner UI and logic.
- Updated `_includes/head.html` to **remove** direct Google Analytics loading and defer it to the consent script.
- Updated `_layouts/default.html` to include the banner in the site footer.
- Analytics script now only loads **after** user clicks 'Approve', persisting consent for 31 days.
- Correctly checks for `site.google_analytics` and `jekyll.environment == 'production'`.

## Behavior
- **Default:** Analytics disabled. Banner shown.
- **On Approve:** Banner hides, cookie set, page reload, Analytics script injected.
- **Subsequent Visits:** Banner hidden, Analytics loaded immediately.