### PR TITLE
fix(ci): only trigger PR preview when _posts/ changes

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches: ["main"]
     types: [opened, synchronize, reopened]
+    paths:
+      - "_posts/**"
 
 permissions:
   contents: write


### PR DESCRIPTION
Add `paths: ["_posts/**"]` filter to `preview.yml` so the workflow only runs on PRs that add or modify blog posts. PRs with only CI/config/docs changes will no longer appear in the drafts index.