### PR TITLE
chore: update slack invite link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ url: "https://blogs.agntcy.org" # the base hostname & protocol for your site, e.
 github_url: "https://github.com/agntcy"
 linkedin_url: "https://www.linkedin.com/company/agntcyproject"
 youtube_url: "https://www.youtube.com/@agntcy-lf"
-slack_url: "https://join.slack.com/t/agntcy/shared_invite/zt-3hb4p7bo0-5H2otGjxGt9OQ1g5jzK_GQ"
+slack_url: "https://join.slack.com/t/agntcy/shared_invite/zt-3xozr6nzq-i6LXv2P8l2kVW4_Prnny2w"
 
 # Google Tag (gtag.js)
 google_analytics: "G-3D9938KZCN"


### PR DESCRIPTION
This PR updates the expired Slack invite link