### PR TITLE
feat: add reading time estimates

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,6 +23,9 @@ header_pages:
 show_excerpts: true
 excerpt_separator: <!--more-->
 
+# Reading time estimate
+reading_words_per_minute: 200
+
 # Build settings
 theme: minima
 plugins:

--- a/_includes/reading_time.html
+++ b/_includes/reading_time.html
@@ -1,0 +1,8 @@
+{%- assign words_per_minute = site.reading_words_per_minute | default: 200 -%}
+{%- assign word_count = include.content | strip_html | number_of_words -%}
+{%- assign minutes = word_count | times: 1.0 | divided_by: words_per_minute | ceil -%}
+{%- if minutes < 1 -%}
+  {%- assign minutes = 1 -%}
+{%- endif -%}
+{%- assign reading_time_label = minutes | append: " min read" -%}
+{{- reading_time_label -}}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -13,7 +13,7 @@ layout: default
     <ul class="post-list">
       {%- for post in paginator.posts -%}
       <li>
-        <span class="post-meta">{{ post.date | date: "%b %-d, %Y" }}</span>
+        <span class="post-meta">{{ post.date | date: "%b %-d, %Y" }} • {% include reading_time.html content=post.content -%}</span>
         <h3>
           <a class="post-link" href="{{ post.url | relative_url }}">
             {{ post.title | escape }}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -21,6 +21,7 @@ layout: default
             {%- endif -%}
           </span>
       {%- endif -%}
+      • {% include reading_time.html content=content -%}
     </p>
   </header>
 


### PR DESCRIPTION
## Summary

- add a reusable Jekyll include for estimating post reading time
- make the words-per-minute rate configurable, with a minimum one-minute estimate
- display reading time on individual posts and the home-page post list

## Validation

- `bundle exec jekyll build`
- `node scripts/build-presentations.mjs`
- verified generated post and home-page HTML contains reading-time estimates
- `git diff --check`

Closes #30
